### PR TITLE
Added WP PHP Console plugin to debug tools

### DIFF
--- a/index.md
+++ b/index.md
@@ -152,6 +152,7 @@ Plugins that help with debugging
 -   [WP-Pretty Debug](https://github.com/wycks/WP-Pretty-Debug) - Pretty var_dumps -links to queryposts.com API
 -   [WP Crontrol](http://wordpress.org/plugins/crontrol/) - Lets you view and control what's happening in the WP-Cron system
 -   [Kint Debugger](http://wordpress.org/plugins/kint-debugger/) - WordPress wrapper for Kint debugging tool. Integrates with the Debug Bar is present.
+-   [WP PHP Console](https://wordpress.org/plugins/wp-php-console/) - Debug WordPress from Chrome Dev Tools console and run your PHP code live from a browser terminal.
 
 ##### Profiling plugins
 


### PR DESCRIPTION
WP PHP Console allows you to handle PHP errors & exceptions, dump variables, execute PHP code remotely and many other things using your browser javascript console. You can also execute PHP code from a terminal without reloading page, including all functions introduced by your WordPress theme or plugin where WP PHP Console runs.