### PR TITLE
Add WP-CLI GUI

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,6 +54,7 @@ Base Tools
 `Command line fu`
 
 -   [WP-CLI](https://github.com/wp-cli/wp-cli) - The command-line tool for managing WordPress.
+-   [WP-CLI GUI](http://wpcligui.com/) - A GUI for the command line interface for WordPress.
 -   [EasyEngine](https://github.com/rtCamp/easyengine/) - Python tool to easily manage your WordPress websites with NGINX webserver - supported on Ubuntu and Debian Linux.
 -   [WP-PowerShell](https://github.com/ericmann/WP-PowerShell) - Windows powershell for the WP-CLI
 -   [VimPress](https://github.com/pentie/VimRepress/) - Post to WordPress from Vim


### PR DESCRIPTION
Quote from the author:

>    I was late to the party but loved WP-CLI at first sight just for performing super fast fresh WordPress installs! What did bug after a few uses was that the time it takes to download WordPress always delays every other command you want to run. I realized I could memorize all the commands and concatenate all the commands I needed, but remembering.. that's so not cool. So instead I wrote WP-CLI GUI v1 to generate the concatenated string. From there, it grew to this.
    - Tim Brugman (@Brugman) "