### PR TITLE
Add DB search and replace utility

### DIFF
--- a/index.md
+++ b/index.md
@@ -117,6 +117,7 @@ Base Tools
 -   [WordPress Java](http://code.google.com/p/wordpress-java/) -  Java xmlrpc interface of WordPress
 -   [WP.NET](http://wpdotnet.com/) - WordPress compiled to .NET, yes this exists.
 -   [WordPress Packagist](http://wpackagist.org/) - Mirror of the wp.org theme and plugin repositories for use with Composer.
+-   [Database Search & Replace script](https://github.com/interconnectit/Search-Replace-DB) - Easily search & replace data in a WP database. Fully supports handling of serialized strings. Especially useful when migrating a site to another domain/from test to production. [Full docs](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/).
 
 * * * * *
 


### PR DESCRIPTION
Easily search & replace data in a WP database. Fully supports handling of serialized strings. Especially useful when migrating a site to another domain/from test to production.